### PR TITLE
Fix pacman orphan cleanup

### DIFF
--- a/scripts/run-maintenance-tasks
+++ b/scripts/run-maintenance-tasks
@@ -38,8 +38,8 @@ cleanup_pacman() {
         sudo pacman -Sc --noconfirm
 
         log "Removing orphaned packages..."
-        if pacman -Qtdq >/dev/null 2>&1; then
-            sudo pacman -Rns "$(pacman -Qtdq)" --noconfirm
+        if mapfile -t orphans < <(pacman -Qtdq 2>/dev/null) && [[ ${#orphans[@]} -gt 0 ]]; then
+            sudo pacman -Rns "${orphans[@]}" --noconfirm
         else
             log "No orphaned packages found"
         fi


### PR DESCRIPTION
## Summary
- ensure pacman orphan removal passes package names separately

## Testing
- `shellcheck scripts/run-maintenance-tasks`
- `bash -n scripts/run-maintenance-tasks`


------
https://chatgpt.com/codex/tasks/task_e_68aee16f3670832eab1811cfacf874c5