### PR TITLE
🔧 Update LLM models to github_copilot/gpt-5

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,12 +25,12 @@ The architecture follows a modular structure where each directory contains relat
 - Make: tabs for recipes; small, composable targets; reuse variables like `DOTFILES`.
 - Configs: keep JSON/TOML valid and minimal; prefer Catppuccin Frappe theme for consistency.
 - Symlinks: use `ln -sf`/`ln -sfT` as in the Makefile; never copy configs to `$HOME`.
-- Be concise and direct
-- Follow existing patterns and conventions in the codebase
-- Verify changes work by running relevant commands
-- Use `sudo` for commands requiring elevated privileges (this matches the Makefile and setup scripts)
+- Be concise and direct.
+- Follow existing patterns and conventions in the codebase.
+- Verify changes work by running relevant commands.
+- Use `sudo` for commands requiring elevated privileges (this matches the Makefile and setup scripts).
 
 ## Commit & Pull Request Guidelines
 
-- Commits: short, imperative, emoji‑prefixed (e.g., `✨ Add plan command`, `🔧 Update settings`).
-- PRs: summary, affected targets/dirs, manual steps (`make` commands), linked issues, screenshots for UI.
+- Commits: concise, short, imperative, emoji‑prefixed (e.g., `✨ Add plan command`, `🔧 Update settings`).
+- PRs: concise summary, relevant context, related issues.

--- a/llm/cmd.yaml
+++ b/llm/cmd.yaml
@@ -1,4 +1,4 @@
-model: github_copilot/claude-sonnet-4
+model: github_copilot/gpt-5
 system: >
   Return only the command to be executed as a raw string, no string delimiters
   wrapping it (like ```), no yapping, no markdown, no fenced code, what you return

--- a/llm/gitcommit.yaml
+++ b/llm/gitcommit.yaml
@@ -1,4 +1,4 @@
-model: github_copilot/claude-sonnet-4
+model: github_copilot/gpt-5
 prompt: >
   Write a descriptive commit following the following specification describing the changes in the following diff.
 

--- a/llm/pyscript.yaml
+++ b/llm/pyscript.yaml
@@ -1,4 +1,4 @@
-model: github-copilot/claude-sonnet-4
+model: github_copilot/gpt-5
 extract: true
 system: >
   You write Python tools / scripts / clis as single files.


### PR DESCRIPTION
### Summary
- Switch default LLM models in `llm/cmd.yaml`, `llm/gitcommit.yaml`, and `llm/pyscript.yaml` to `github_copilot/gpt-5`.
- Tidy punctuation and PR/commit guidelines in `AGENTS.md`.

### Context
- Keeps LLM config consistent across commands.
- Aligns docs with current conventions (concise, emoji‑prefixed commits).